### PR TITLE
Add Ubuntu 24.04 build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ or
 ```console
 ./build-ubuntu-22.04.sh
 ```
+or
+```console
+./build-ubuntu-24.04.sh
+```
 
 ## Building on Windows
 

--- a/build-ubuntu-24.04.sh
+++ b/build-ubuntu-24.04.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# dotnet 8 or higher is included in Ubuntu 24.04 and up
+
+# install dev-dependencies
+sudo apt-get update; \
+  sudo apt-get -y install dotnet-sdk-8.0 git cmake clang ninja-build build-essential libssl-dev pkg-config libboost-all-dev libsodium-dev libzmq5 libgmp-dev libc++-dev zlib1g-dev
+
+(cd src/Miningcore && \
+BUILDIR=${1:-../../build} && \
+echo "Building into $BUILDIR" && \
+dotnet publish -c Release --framework net6.0 -o $BUILDIR)


### PR DESCRIPTION
## Summary
- add `build-ubuntu-24.04.sh` for Ubuntu 24.04 systems
- document the new build script in README

