### PR TITLE
Add quick start docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to Miningcore
+
+Thank you for considering a contribution! Pull requests against the `dev` branch are welcome.
+
+Please follow these guidelines:
+
+- Use clear commit messages in English.
+- Run `dotnet test` before submitting your PR.
+- Format C# code with `dotnet format`.
+
+Feel free to open a discussion first if you plan a larger change.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@
 - Detailed per-pool logging to console & filesystem
 - Runs on Linux and Windows
 
+## Quick Start
+
+```console
+git clone https://github.com/blackmennewstyle/miningcore
+cd miningcore
+./build-ubuntu-22.04.sh   # choose the script that matches your OS
+cp examples/ethereum_pool.json config.json
+cd build
+Miningcore -c config.json
+```
+
 ## Support
 
 Commercial support directly by the maintainer is available through [miningcore.pro](https://store.miningcore.pro).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,12 @@
+# Example Configurations
+
+This directory contains sample pool configuration files. Copy the configuration that matches your coin and adjust the wallet addresses and daemon connection parameters.
+
+Typical usage:
+
+```bash
+cp examples/ethereum_pool.json config.json
+# edit config.json and change wallet addresses and daemon ports
+```
+
+See the [Configuration wiki](https://github.com/oliverw/miningcore/wiki/Configuration) for a full description of all options.


### PR DESCRIPTION
## Summary
- add a Quick Start section to the README
- document example configuration usage
- add a CONTRIBUTING guide

## Testing
- `dotnet test src` *(fails: building native libs interrupted)*

